### PR TITLE
ATH-2632: Allow sending metadata and tags to the dataset

### DIFF
--- a/athina_client/datasets/dataset.py
+++ b/athina_client/datasets/dataset.py
@@ -33,9 +33,9 @@ class Dataset:
     def create(
         name: str,
         description: Optional[str] = None,
-        language_model_id: Optional[str] = None,
-        prompt_template: Optional[Any] = None,
-        rows: List[Dict[str, Any]] = None,
+        rows: Optional[List[Dict[str, Any]]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
         project_name: Optional[str] = None,
     ) -> "Dataset":
         """
@@ -59,9 +59,9 @@ class Dataset:
             "source": "dev_sdk",
             "name": name,
             "description": description,
-            "language_model_id": language_model_id,
-            "prompt_template": prompt_template,
             "dataset_rows": rows,
+            "metadata": metadata,
+            "tags": tags,
             "project_name": project_name if project_name is not None else None,
         }
 
@@ -83,7 +83,6 @@ class Dataset:
         )
         return dataset
 
-
     @staticmethod
     def change_project(dataset_id: str, project_name: str) -> Dict[str, Any]:
         """
@@ -104,7 +103,6 @@ class Dataset:
             return response
         except Exception as e:
             raise CustomException("Error changing project for dataset", str(e))
-
 
     @staticmethod
     def add_rows(dataset_id: str, rows: List[Dict[str, Any]]):

--- a/examples/datasets.ipynb
+++ b/examples/datasets.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,15 +19,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "try:\n",
     "    dataset = Dataset.create(\n",
-    "        name='test_dataset_2014',\n",
-    "        description='This is a test dataset',\n",
-    "        language_model_id='gpt-4o',\n",
+    "        name='claude_35_sonnet_dataset_test_2',\n",
+    "        # example\n",
+    "        description='Claude 3.5 sonnet test dataset',\n",
+    "        metadata={\n",
+    "            'model': 'claude-3.5-sonnet'\n",
+    "        },\n",
+    "        tags=['test'],\n",
     "        rows=[\n",
     "            {\n",
     "                'query': 'What is the capital of Greece?',\n",
@@ -44,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +61,6 @@
     "                'context': ['France is a country in Western Europe.', 'Paris is the capital of France.'],\n",
     "                'response': 'Paris',\n",
     "                'expected_response': 'Paris',\n",
-    "                '__id': '1'\n",
     "            },\n",
     "        ]\n",
     "    )\n",
@@ -147,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Added:**
- `metadata`: dict
- `tags`: list[str]

**Removed:**
- `prompt_template` 
- `language_model_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset creation process with updated parameters for `rows`, `metadata`, and `tags`.
	- Introduced a new dataset example in the Jupyter notebook with updated metadata and tags.

- **Bug Fixes**
	- Removed the `__id` field from row dictionaries to streamline dataset creation.

- **Documentation**
	- Updated Jupyter notebook to reflect changes in dataset creation and execution context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->